### PR TITLE
Add pan + other ergonomics elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,12 +30,14 @@ use bevy::input::mouse::MouseScrollUnit::{Line, Pixel};
 use bevy::input::mouse::MouseWheel;
 use bevy::prelude::*;
 use bevy::render::camera::Camera;
+use std::ops::RangeInclusive;
 
 const LINE_TO_PIXEL_RATIO: f32 = 0.1;
 
 pub struct OrbitCamera {
     pub x: f32,
     pub y: f32,
+    pub pitch_range: RangeInclusive<f32>,
     pub distance: f32,
     pub center: Vec3,
     pub rotate_sensitivity: f32,
@@ -50,7 +52,8 @@ impl Default for OrbitCamera {
     fn default() -> Self {
         OrbitCamera {
             x: 0.0,
-            y: 0.0,
+            y: std::f32::consts::FRAC_PI_2,
+            pitch_range: 0.01..=3.13,
             distance: 5.0,
             center: Vec3::ZERO,
             rotate_sensitivity: 1.0,
@@ -75,6 +78,18 @@ impl OrbitCamera {
 
 pub struct OrbitCameraPlugin;
 impl OrbitCameraPlugin {
+    fn update_transform_system(mut query: Query<(&OrbitCamera, &mut Transform), (Changed<OrbitCamera>, With<Camera>)>) {
+        for (camera, mut transform) in query.iter_mut() {
+            if camera.enabled {
+                let rot = Quat::from_axis_angle(Vec3::Y, camera.x)
+                    * Quat::from_axis_angle(-Vec3::X, camera.y);
+                transform.translation =
+                    (rot * Vec3::Y) * camera.distance + camera.center;
+                transform.look_at(camera.center, Vec3::Y);
+            }
+        }
+    }
+
     fn mouse_motion_system(
         time: Res<Time>,
         mut mouse_motion_events: EventReader<MouseMotion>,
@@ -85,7 +100,7 @@ impl OrbitCameraPlugin {
         for event in mouse_motion_events.iter() {
             delta += event.delta;
         }
-        for (mut camera, mut transform, _) in query.iter_mut() {
+        for (mut camera, transform, _) in query.iter_mut() {
             if !camera.enabled {
                 continue;
             }
@@ -93,30 +108,21 @@ impl OrbitCameraPlugin {
             if mouse_button_input.pressed(camera.rotate_button) {
                 camera.x -= delta.x * camera.rotate_sensitivity * time.delta_seconds();
                 camera.y -= delta.y * camera.rotate_sensitivity * time.delta_seconds();
-
-                camera.y = camera.y.max(0.01).min(3.13);
-
-                let rot = Quat::from_axis_angle(Vec3::Y, camera.x)
-                    * Quat::from_axis_angle(-Vec3::X, camera.y);
-                transform.translation =
-                    (rot * Vec3::new(0.0, 1.0, 0.0)) * camera.distance + camera.center;
-                transform.look_at(camera.center, Vec3::Y);
+                camera.y = camera.y.max(*camera.pitch_range.start()).min(*camera.pitch_range.end());
             }
-            
+
             if mouse_button_input.pressed(camera.pan_button) {
                 let right_dir = transform.rotation * -Vec3::X;
                 let up_dir = transform.rotation * Vec3::Y;
-
                 let pan_vector = (delta.x * right_dir + delta.y * up_dir) * camera.pan_sensitivity * time.delta_seconds();
                 camera.center += pan_vector;
-                transform.translation += pan_vector;
             }
         }
     }
 
     fn zoom_system(
         mut mouse_wheel_events: EventReader<MouseWheel>,
-        mut query: Query<(&mut OrbitCamera, &mut Transform, &mut Camera)>,
+        mut query: Query<&mut OrbitCamera, With<Camera>>,
     ) {
         let mut total = 0.0;
         for event in mouse_wheel_events.iter() {
@@ -126,20 +132,17 @@ impl OrbitCameraPlugin {
                     Pixel => LINE_TO_PIXEL_RATIO,
                 };
         }
-        for (mut camera, mut transform, _) in query.iter_mut() {
-            if !camera.enabled {
-                continue;
+        for mut camera in query.iter_mut() {
+            if camera.enabled {
+                camera.distance *= camera.zoom_sensitivity.powf(total);
             }
-            camera.distance *= camera.zoom_sensitivity.powf(total);
-            let translation = &mut transform.translation;
-            *translation =
-                (*translation - camera.center).normalize() * camera.distance + camera.center;
         }
     }
 }
 impl Plugin for OrbitCameraPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_system(Self::mouse_motion_system.system())
-            .add_system(Self::zoom_system.system());
+            .add_system(Self::zoom_system.system())
+            .add_system(Self::update_transform_system.system());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,10 @@ pub struct OrbitCamera {
     pub distance: f32,
     pub center: Vec3,
     pub rotate_sensitivity: f32,
+    pub pan_sensitivity: f32,
     pub zoom_sensitivity: f32,
+    pub rotate_button: MouseButton,
+    pub pan_button: MouseButton,
     pub enabled: bool,
 }
 
@@ -51,7 +54,10 @@ impl Default for OrbitCamera {
             distance: 5.0,
             center: Vec3::ZERO,
             rotate_sensitivity: 1.0,
+            pan_sensitivity: 1.0,
             zoom_sensitivity: 0.8,
+            rotate_button: MouseButton::Left,
+            pan_button: MouseButton::Right,
             enabled: true,
         }
     }
@@ -60,13 +66,9 @@ impl Default for OrbitCamera {
 impl OrbitCamera {
     pub fn new(dist: f32, center: Vec3) -> OrbitCamera {
         OrbitCamera {
-            x: 0.0,
-            y: 0.0,
             distance: dist,
             center,
-            rotate_sensitivity: 1.0,
-            zoom_sensitivity: 0.8,
-            enabled: true,
+            ..Self::default()
         }
     }
 }
@@ -87,7 +89,8 @@ impl OrbitCameraPlugin {
             if !camera.enabled {
                 continue;
             }
-            if mouse_button_input.pressed(MouseButton::Left) {
+
+            if mouse_button_input.pressed(camera.rotate_button) {
                 camera.x -= delta.x * camera.rotate_sensitivity * time.delta_seconds();
                 camera.y -= delta.y * camera.rotate_sensitivity * time.delta_seconds();
 
@@ -98,6 +101,15 @@ impl OrbitCameraPlugin {
                 transform.translation =
                     (rot * Vec3::new(0.0, 1.0, 0.0)) * camera.distance + camera.center;
                 transform.look_at(camera.center, Vec3::Y);
+            }
+            
+            if mouse_button_input.pressed(camera.pan_button) {
+                let right_dir = transform.rotation * -Vec3::X;
+                let up_dir = transform.rotation * Vec3::Y;
+
+                let pan_vector = (delta.x * right_dir + delta.y * up_dir) * camera.pan_sensitivity * time.delta_seconds();
+                camera.center += pan_vector;
+                transform.translation += pan_vector;
             }
         }
     }


### PR DESCRIPTION
This PR adds the following:
- Pan the camera when the user right-click+move the mouse.
- The mouse buttons associated to rotation and panning are now configurable by the user.
- The camera will update the `Transform` component if the user modified it (before, the transform was only updated after a mouse action).
- The default camera `y` rotation was outside of the allowed range `0.01..3.13`. The default value has been changed to `pi / 2` in order to lie inside of the allowed range.

Please let me know if any of these changes are not wanted. 