### PR TITLE
Emit & consume events to make re-using orbit functionality easier

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,12 @@ use std::ops::RangeInclusive;
 
 const LINE_TO_PIXEL_RATIO: f32 = 0.1;
 
+pub enum CameraEvents {
+    Orbit(Vec2),
+    Pan(Vec2),
+    Zoom(f32),
+}
+
 pub struct OrbitCamera {
     pub x: f32,
     pub y: f32,
@@ -78,51 +84,80 @@ impl OrbitCamera {
 
 pub struct OrbitCameraPlugin;
 impl OrbitCameraPlugin {
-    fn update_transform_system(mut query: Query<(&OrbitCamera, &mut Transform), (Changed<OrbitCamera>, With<Camera>)>) {
+    pub fn update_transform_system(
+        mut query: Query<(&OrbitCamera, &mut Transform), (Changed<OrbitCamera>, With<Camera>)>,
+    ) {
         for (camera, mut transform) in query.iter_mut() {
             if camera.enabled {
                 let rot = Quat::from_axis_angle(Vec3::Y, camera.x)
                     * Quat::from_axis_angle(-Vec3::X, camera.y);
-                transform.translation =
-                    (rot * Vec3::Y) * camera.distance + camera.center;
+                transform.translation = (rot * Vec3::Y) * camera.distance + camera.center;
                 transform.look_at(camera.center, Vec3::Y);
             }
         }
     }
 
-    fn mouse_motion_system(
-        time: Res<Time>,
+    pub fn emit_motion_events(
+        mut events: EventWriter<CameraEvents>,
         mut mouse_motion_events: EventReader<MouseMotion>,
         mouse_button_input: Res<Input<MouseButton>>,
-        mut query: Query<(&mut OrbitCamera, &mut Transform, &mut Camera)>,
+        mut query: Query<&OrbitCamera>,
     ) {
         let mut delta = Vec2::ZERO;
         for event in mouse_motion_events.iter() {
             delta += event.delta;
         }
+        for camera in query.iter_mut() {
+            if camera.enabled {
+                if mouse_button_input.pressed(camera.rotate_button) {
+                    events.send(CameraEvents::Orbit(delta))
+                }
+
+                if mouse_button_input.pressed(camera.pan_button) {
+                    events.send(CameraEvents::Pan(delta))
+                }
+            }
+        }
+    }
+
+    pub fn mouse_motion_system(
+        time: Res<Time>,
+        mut events: EventReader<CameraEvents>,
+        mut query: Query<(&mut OrbitCamera, &mut Transform, &mut Camera)>,
+    ) {
         for (mut camera, transform, _) in query.iter_mut() {
             if !camera.enabled {
                 continue;
             }
 
-            if mouse_button_input.pressed(camera.rotate_button) {
-                camera.x -= delta.x * camera.rotate_sensitivity * time.delta_seconds();
-                camera.y -= delta.y * camera.rotate_sensitivity * time.delta_seconds();
-                camera.y = camera.y.max(*camera.pitch_range.start()).min(*camera.pitch_range.end());
-            }
-
-            if mouse_button_input.pressed(camera.pan_button) {
-                let right_dir = transform.rotation * -Vec3::X;
-                let up_dir = transform.rotation * Vec3::Y;
-                let pan_vector = (delta.x * right_dir + delta.y * up_dir) * camera.pan_sensitivity * time.delta_seconds();
-                camera.center += pan_vector;
+            for event in events.iter() {
+                match event {
+                    CameraEvents::Orbit(delta) => {
+                        camera.x -= delta.x * camera.rotate_sensitivity * time.delta_seconds();
+                        camera.y -= delta.y * camera.rotate_sensitivity * time.delta_seconds();
+                        camera.y = camera
+                            .y
+                            .max(*camera.pitch_range.start())
+                            .min(*camera.pitch_range.end());
+                    }
+                    CameraEvents::Pan(delta) => {
+                        let right_dir = transform.rotation * -Vec3::X;
+                        let up_dir = transform.rotation * Vec3::Y;
+                        let pan_vector = (delta.x * right_dir + delta.y * up_dir)
+                            * camera.pan_sensitivity
+                            * time.delta_seconds();
+                        camera.center += pan_vector;
+                    }
+                    _ => {}
+                }
             }
         }
     }
 
-    fn zoom_system(
+    pub fn emit_zoom_events(
+        mut events: EventWriter<CameraEvents>,
         mut mouse_wheel_events: EventReader<MouseWheel>,
-        mut query: Query<&mut OrbitCamera, With<Camera>>,
+        mut query: Query<&OrbitCamera>,
     ) {
         let mut total = 0.0;
         for event in mouse_wheel_events.iter() {
@@ -132,17 +167,38 @@ impl OrbitCameraPlugin {
                     Pixel => LINE_TO_PIXEL_RATIO,
                 };
         }
+
+        if total != 0.0 {
+            for camera in query.iter_mut() {
+                if camera.enabled {
+                    events.send(CameraEvents::Zoom(total));
+                }
+            }
+        }
+    }
+
+    pub fn zoom_system(
+        mut query: Query<&mut OrbitCamera, With<Camera>>,
+        mut events: EventReader<CameraEvents>,
+    ) {
         for mut camera in query.iter_mut() {
-            if camera.enabled {
-                camera.distance *= camera.zoom_sensitivity.powf(total);
+            for event in events.iter() {
+                if camera.enabled {
+                    if let CameraEvents::Zoom(distance) = event {
+                        camera.distance *= camera.zoom_sensitivity.powf(*distance);
+                    }
+                }
             }
         }
     }
 }
 impl Plugin for OrbitCameraPlugin {
     fn build(&self, app: &mut AppBuilder) {
-        app.add_system(Self::mouse_motion_system.system())
+        app.add_system(Self::emit_motion_events.system())
+            .add_system(Self::mouse_motion_system.system())
+            .add_system(Self::emit_zoom_events.system())
             .add_system(Self::zoom_system.system())
-            .add_system(Self::update_transform_system.system());
+            .add_system(Self::update_transform_system.system())
+            .add_event::<CameraEvents>();
     }
 }


### PR DESCRIPTION
This separates input consumption, camera action functionality, into separate functions, and uses bevy's Event system to pass events between.

This enables 3rd parties to have more advanced/quirky key & mouse bindings by emitting events directly themselves.

Cheers